### PR TITLE
Add lizzo footer

### DIFF
--- a/global-styles/style.css
+++ b/global-styles/style.css
@@ -14,8 +14,13 @@ li {
 }
 
 footer {
-    background-image: linear-gradient(to right, #D99AC5, #6CD4FF);
-    padding: 3%;
+    background-image: linear-gradient(to right, rgba(217, 154, 197, 0.452), rgba(108, 211, 255, 0.507)), url(https://cuziloveyou.lizzomusic.com/sites/g/files/g2000008501/files/CILY_cutout.png);
+    background-position: 0, center bottom;
+    background-size: cover, 400px;
+    background-attachment: fixed;
+    background-repeat: no-repeat;
+    padding: 0;
+    height: 300px;
 }
 
 footer .links {

--- a/global-styles/style.css
+++ b/global-styles/style.css
@@ -20,7 +20,7 @@ footer {
     background-attachment: fixed;
     background-repeat: no-repeat;
     padding: 0;
-    height: 300px;
+    height: 305px;
 }
 
 footer .links {

--- a/news-feed/index.html
+++ b/news-feed/index.html
@@ -62,7 +62,7 @@
                     <p>Event Already Happened</p>
                 </div>
             </div>
-            <div class="card">
+            <!-- <div class="card">
                 <img src="imagelink">
                 <div class="container">
                     <h2>What</h2>
@@ -72,7 +72,7 @@
                             href="ticketlink">Get
                             Tickets</a></p>
                 </div>
-            </div>
+            </div> -->
         </div>
         <H1>Film</H1>
         <div class="film-cards">
@@ -91,6 +91,7 @@
             
             <div class="card">
                 <!-- add image container -->
+                
                 <img src="https://upload.wikimedia.org/wikipedia/en/d/d9/Hustlers_%28Official_Film_Poster%29.png">
                 <div class="container">
                     <h2>Hustlers</h2>


### PR DESCRIPTION
get fetch --all
git checkout addLizzoFooter
hs -o
1. Footer has picture of Lizzo as background with the gradient as an overlay
2. Lizzo is fixed in position.
3. You can see all of the image, nothing's cut off other than a small part of her foot.
(This won't apply to the footers on the main page or the personal page yet, as those footers are not on the bottom yet)